### PR TITLE
Fix issue with Imgur uploads consistently failing

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -189,6 +189,10 @@ static NSString *imageID;
         NSMutableURLRequest *mutableRequest = [request mutableCopy];
         // Insert the api credential and update the request on this session task
         [mutableRequest setValue:[NSString stringWithFormat:@"Client-ID %@", kClientID] forHTTPHeaderField:@"Authorization"];
+        // Set or else upload will fail with 400
+        if ([requestURL isEqualToString:@"https://api.imgur.com/3/image"]) {
+            [mutableRequest setValue:@"image/jpeg" forHTTPHeaderField:@"Content-Type"];
+        }
         [self setValue:mutableRequest forKey:@"_originalRequest"];
         [self setValue:mutableRequest forKey:@"_currentRequest"];
     }


### PR DESCRIPTION
Imgur API was returning 400 Bad Request for image uploads due to the POST request having the `Content-Type` header set to `application/x-www-form-urlencoded`. Setting it an image type like `image/jpeg` or `image/png` seems to fix the issue (I verified it does **not** have to match the actual image type being uploaded).