### PR TITLE
Update README with "responsible" builder policy warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ TrollStore IPA: [AppStore++_TrollStore_v1.0.3-2.ipa](https://github.com/CokePoke
 
 Repo: https://cokepokes.github.io
 
+> [!WARNING]
+> Per the recent [Responsible Builder Policy](https://www.reddit.com/r/redditdev/comments/1oug31u/introducing_the_responsible_builder_policy_new/), you can no longer generated new API keys that use Oauth without Reddit's explicit approval. If you have an existing key, you should still be able to use this. If you do not and/or are setting this up for the first time, you are out of luck.
+
 ## Reddit Settings
 
 sign out of all accounts in Apollo before installing


### PR DESCRIPTION
This PR adds a warning to the README that about oauth keys in 2026 based on a new reddit policy from 3mo ago.

Reddit doing reddit things, still thinking their platform is worth something. 

https://www.reddit.com/r/redditdev/comments/1oug31u/introducing_the_responsible_builder_policy_new/

TL;DR You cannot generate new oauth keys anymore without Reddit's explicit approval. Existing keys will work, but you can never create new.

Even if you were brave enough to submit a request, do you really think they'd respond in a timely manner or even consider approving it?